### PR TITLE
Add directions for ChromeOS Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,33 @@ Then paste the following lines and save the file.
 "editor.fontLigatures": true,
 ```
 
+### **ChromeOS Terminal**
+In the terminal:
+1. Use the keyboard shortcut <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> to open up settings.
+2. Scroll down to "Custom CSS (Inline Text)".
+3. Copy & paste the following:
+
+```
+@font-face{
+    font-family: 'JetBrains Mono';
+    src: url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/eot/JetBrainsMono-Regular.eot') format('embedded-opentype'),
+         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/woff2/JetBrainsMono-Regular.woff2') format('woff2'),
+         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/woff/JetBrainsMono-Regular.woff') format('woff'),
+         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/ttf/JetBrainsMono-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+* {
+    -webkit-font-feature-settings: "liga" on, "calt" on;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    font-family: 'JetBrains Mono';
+}
+```
+
+4. There is no step 4!
+
 ## Source files
 
 Can be found in the *"Source"* folder. To open them you will need FontLab 6 or higher.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ In the terminal:
 }
 ```
 
-4. There is no step 4!
-
 ## Source files
 
 Can be found in the *"Source"* folder. To open them you will need FontLab 6 or higher.


### PR DESCRIPTION
This adds the steps for how to use this with a ChromeOS device's built in terminal.