### PR TITLE
Added install manual script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Select JetBrains Mono in the IDE settings: go to `Preferences/Settings` → `Edi
    - Linux. Open a terminal and run the following:
    
       ```bash
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nisrulz/JetBrainsMono/add/install-manual-script/install_manual.sh)"
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/install_manual.sh)"
       ```
 
 #### Picking the font for your IDE

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Select JetBrains Mono in the IDE settings: go to `Preferences/Settings` → `Edi
    - Linux. Open a terminal and run the following:
    
       ```bash
-      unzip <font_file.zip> -d ~/.local/share/fonts && fc-cache -fv
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nisrulz/JetBrainsMono/add/install-manual-script/install_manual.sh)"
       ```
 
 #### Picking the font for your IDE

--- a/install_manual.sh
+++ b/install_manual.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "Installing JetBrains Mono Fonts"
+echo ""
+# Get the download URL of the latest release from Github
+FONT_URL=$(curl -s https://api.github.com/repos/JetBrains/JetBrainsMono/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+
+# Extract the Zip filename
+FONT_ZIP_FILENAME=$(echo $FONT_URL | cut -d '/' -f 9)
+
+# Download the zip file from Github Releases using wget
+wget $FONT_URL 1>/dev/null 2>&1
+
+# Unzip and move to fonts directory
+unzip $FONT_ZIP_FILENAME -d ~/.local/share/fonts && fc-cache -fv
+
+# Clenaup: Remove the downloaded zip file
+rm $FONT_ZIP_FILENAME


### PR DESCRIPTION
I tested the script on my branch using below command:

```sh
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nisrulz/JetBrainsMono/add/install-manual-script/install_manual.sh)
```

The URL is built like below:

`https://raw.githubusercontent.com/<username>/JetBrainsMono/<branch_name>/install_manual.sh`

The PR has the one setup for the JetBrains and master branch, in the readme.

PR Merge: Squash