### PR TITLE
README.md: remove mention of Apache v2.0 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ Can be found in the *"Source"* folder. To open them you will need FontLab 6 or h
 
 JetBrains Mono typeface is available under the [OFL-1.1 License](https://github.com/JetBrains/JetBrainsMono/blob/master/LICENSE) and can be used free of charge, for both commercial and non-commercial purposes. You do not need to give credit to JetBrains, although we will appreciate it very much if you do.
 
-The source code is available under [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
-
 ## Credits
 
 **Type designer**\


### PR DESCRIPTION
In commit 09d45c95de9a6cdd8949892129cb76161b958d3e, the SOURCE_CODE_LICENSE file is deleted.

We assume that the goal is to move the whole project under SIL instead of Apache v2.0. This is why the mention of the Apache v2.0 license for source code should be removed, as the Apache v2.0 license file has been removed.