### PR TITLE
Updated requirements and dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ fontmake
 gftools
 ttfautohint-py
 fontbakery
+brotli

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@
 absl-py==0.10.0           # via gftools
 appdirs==1.4.4            # via fs
 attrs==20.2.0             # via fontmake, ufolib2
-beautifulsoup4==4.9.1     # via fontbakery
+beautifulsoup4==4.9.3     # via fontbakery
 booleanoperations==0.9.0  # via fontmake, ufo2ft
+brotli==1.0.9             # via -r requirements.in
 cached-property==1.5.2    # via pygit2
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via pygit2
@@ -22,22 +23,23 @@ defcon==0.7.2             # via fontbakery
 deprecated==1.2.10        # via pygithub
 flask==1.1.2              # via gftools
 font-v==1.0.3             # via fontbakery
-fontbakery==0.7.29        # via -r requirements.in
+fontbakery==0.7.31        # via -r requirements.in
 fontmake==2.2.1           # via -r requirements.in
 fontmath==0.6.0           # via fontmake
-fonttools[lxml,ufo,unicode]==4.15.0  # via booleanoperations, cffsubr, compreffor, cu2qu, defcon, font-v, fontbakery, fontmake, fontmath, gftools, glyphslib, ufo2ft, ufolib2, ufolint, vttlib
+fonttools[lxml,ufo,unicode]==4.16.1  # via booleanoperations, cffsubr, compreffor, cu2qu, defcon, font-v, fontbakery, fontmake, fontmath, gftools, glyphslib, ufo2ft, ufolib2, ufolint, vttlib
 fs==2.4.11                # via fonttools
-gftools==0.4.2            # via -r requirements.in
+gftools==0.4.4            # via -r requirements.in
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via font-v
+gitpython==3.1.9          # via font-v
 glyphslib==5.2.0          # via fontmake, gftools
 idna==2.10                # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 lxml==4.5.2               # via fontbakery, fonttools
 markupsafe==1.1.1         # via jinja2
-opentype-sanitizer==8.0.0.post2  # via fontbakery, gftools
-pillow==7.0.0             # via gftools
+opentype-sanitizer==8.1.0  # via fontbakery, gftools
+pillow==8.0.0             # via gftools
+pip-api==0.0.14           # via fontbakery
 protobuf==3.13.0          # via fontbakery, gftools
 pyclipper==1.2.0          # via booleanoperations
 pycparser==2.20           # via cffi
@@ -68,4 +70,5 @@ werkzeug==1.0.1           # via flask
 wrapt==1.12.1             # via deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
For the requirements.txt to be updated when run `pip-compile requirements.in`, you actually need to delete requirements.txt for it to not interfere with pip-compile. You can then reinstall your virtual environment.