### PR TITLE
Remove links to fonts that don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ In the terminal:
 ```css
 @font-face{
     font-family: 'JetBrains Mono';
-    src: url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/fonts/webfonts/JetBrainsMono-Regular.eot') format('embedded-opentype'),
-         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/fonts/webfonts/JetBrainsMono-Regular.woff2') format('woff2'),
-         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/fonts/webfonts/JetBrainsMono-Regular.woff') format('woff'),
+    src: url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/fonts/webfonts/JetBrainsMono-Regular.woff2') format('woff2'),
          url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/fonts/ttf/JetBrainsMono-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;


### PR DESCRIPTION
Only the woff2 extension is available in the [webfonts](https://github.com/JetBrains/JetBrainsMono/tree/master/fonts/webfonts) folder.

I've removed links to fonts that don't exist.