### PR TITLE
Enable colors on FontBakery output (Github Actions)

### DIFF
--- a/.github/workflows/Fontbakery-ci-variable-fonts.yml
+++ b/.github/workflows/Fontbakery-ci-variable-fonts.yml
@@ -44,5 +44,5 @@ jobs:
         with:
           version: "latest"
           subcmd: "check-googlefonts"
-          args: "-C --succinct --loglevel WARN"
+          args: "--succinct --loglevel WARN"
           path: "fonts/variable/*.ttf"

--- a/.github/workflows/fontbakery-ci-statics.yml
+++ b/.github/workflows/fontbakery-ci-statics.yml
@@ -40,5 +40,5 @@ jobs:
         with:
           version: "latest"
           subcmd: "check-googlefonts"
-          args: "-C --succinct --loglevel WARN -x familyname -x fullfontname -x typographicfamilyname"
+          args: "--succinct --loglevel WARN -x familyname -x fullfontname -x typographicfamilyname"
           path: "fonts/ttf/*.ttf"


### PR DESCRIPTION
I noticed that you had colors disabled. This PR re-enables colors in order to get better legibility of the FontBakery report.

Here are a couple comparative screenshots:

## Without colors
![Screenshot from 2020-12-07 06-23-26](https://user-images.githubusercontent.com/213676/101333903-f2b11800-3855-11eb-9068-327ea0f13e55.png)

## With colors
![Screenshot from 2020-12-07 06-31-02](https://user-images.githubusercontent.com/213676/101334000-11171380-3856-11eb-94eb-78c7f4d00cf5.png)