### PR TITLE
Address shellcheck warnings

### DIFF
--- a/install_manual.sh
+++ b/install_manual.sh
@@ -93,7 +93,7 @@ function build_fonts_cache() {
 
 # Remove list temporary files
 function cleanup() {
-  for delme in ${*}; do
+  for delme in "$@"; do
     unlink "${delme}" || die "Unable to unlink: ${delme}"
   done
 }

--- a/install_manual.sh
+++ b/install_manual.sh
@@ -63,7 +63,7 @@ function get_item() {
   item="${1}"
   read_from="${2}"
 
-  awk -F '"' "/${item}/ {print \$4}" ${read_from}
+  awk -F '"' "/${item}/ {print \$4}" "${read_from}"
 
 }
 


### PR DESCRIPTION
The script `install_manual.sh` has two [shellcheck](https://github.com/koalaman/shellcheck) warnings:
* Line 66: [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086)
* Line 96: [SC2048](https://github.com/koalaman/shellcheck/wiki/SC2048)

This pull request removes the warnings by applying the suggested solution.