### PR TITLE
Add ttfautohint install in Ubuntu GHA runner

### DIFF
--- a/.github/workflows/Fontbakery-ci-variable-fonts.yml
+++ b/.github/workflows/Fontbakery-ci-variable-fonts.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           update-wheel: "true"
           update-setuptools: "true"
+      - name: Install ttfautohint
+        run: |
+          sudo apt-get update
+          sudo apt-get install ttfautohint
       - name: Build variable fonts
         run: sources/build-vf.sh
       - name: Font Bakery CI variable fonts


### PR DESCRIPTION
ttfautohint-py wrapper was removed from gftools dependencies and it creates an error in Fontbakery CI. This fix the problem.