### PR TITLE
Speed up CI/CD builds approximately more than on 50%

### DIFF
--- a/sources/build-webfonts.sh
+++ b/sources/build-webfonts.sh
@@ -17,20 +17,20 @@ mkdir -p $WEB_DIR
 echo ".
 BUILDING WEBFONTS
 ."
-ttfs=$(ls $TT_DIR/*.ttf)
-for font in $ttfs
-do
-	fonttools ttLib.woff2 compress $font
-done
+
+# Looking up for '*.ttf' in $TT_DIR and compress them (in parallel)
+find $TT_DIR -type f -name '*.ttf' -print0 | xargs -I {} -P0 -0 sh -c "
+	fonttools ttLib.woff2 compress {}
+"
 
 echo ".
 MOVE WEBFONTS TO OWN DIRECTORY
 ."
-webfonts=$(ls $TT_DIR/*.woff*)
-for font in $webfonts
-do
-  mv $font $WEB_DIR
-done
+
+# Looking up for '*.woff*' in $TT_DIR and move them to $WEB_DIR (in parallel)
+find $TT_DIR -type f -regex '*.woff*' -print0 | xargs -I {} -P0 -0 sh -c "
+	mv {} $WEB_DIR
+"
 
 echo ".
 COMPLETE!


### PR DESCRIPTION
Hi.

I have rewrite a little scripts (in '**sources**' dir) and got speed boost more than on 50%.
I think it will improve your building timings in `CI/CD`.

Results on `Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz` (4 cores):

| Script | Execution time BEFORE | Execution time AFTER | Speed boost |
| ------------- | ------------- | ------------- | ------------- |
| sources/`build-statics.sh`  | 2.54 min. |  1.10 min. | faster more than on **`59%`** |
| sources/`build-vf.sh`  | 24 sec.  | 13 sec. | faster more than on **`45%`** |
| sources/`build-webfonts.sh`  | 21 sec.  | 6 sec. | faster more than on **`70%`** |

Proofs:

```bash
###########################################################################
# Timings BEFORE:

manlix@lab:~/git/mono$ time ./sources/build-statics.sh
...
real	2m54.585s     <---
user	3m29.372s
sys	0m4.632s

# Timings AFTER:

manlix@lab:~/git/mono$ time ./sources/build-statics.sh
...
real	1m10.804s     <-------------------------- faster more than on 59%
user	3m46.461s
sys	0m5.748s

###########################################################################
# Timings BEFORE:

manlix@lab:~/git/mono$ time ./sources/build-vf.sh
...
real	0m24.533s     <---
user	0m23.745s
sys	0m0.777s


# Timings AFTER:

manlix@lab:~/git/mono$ time ./sources/build-vf.sh
...
real	0m13.012s     <-------------------------- faster more than on 45%
user	0m24.797s
sys	0m0.845s

###########################################################################
# Timings BEFORE:

manlix@lab:~/git/mono$ time ./sources/build-webfonts.sh
...
real	0m21.728s     <---
user	0m21.275s
sys	0m0.424s


# Timings AFTER:

manlix@lab:~/git/mono$ time ./sources/build-webfonts.sh
...
real	0m6.131s     <-------------------------- faster more than on 70%
user	0m22.977s
sys	0m0.465s

###########################################################################
```

_p.s. Tested on Ubuntu 20.04.2 LTS_