### PR TITLE
Fix #454

### DIFF
--- a/sources/build-statics.sh
+++ b/sources/build-statics.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-source env/bin/activate
+[ -r env/bin/activate ] && . env/bin/activate
 set -e
 
 thisFont="JetBrainsMono"  #must match the name in the font file

--- a/sources/build-vf.sh
+++ b/sources/build-vf.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-. env/bin/activate
+[ -r env/bin/activate ] && . env/bin/activate
 set -e
 
 thisFont="JetBrainsMono"  #must match the name in the font file

--- a/sources/build-vf.sh
+++ b/sources/build-vf.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-source env/bin/activate
+. env/bin/activate
 set -e
 
 thisFont="JetBrainsMono"  #must match the name in the font file

--- a/sources/build-webfonts.sh
+++ b/sources/build-webfonts.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-
-source env/bin/activate
+[ -r env/bin/activate ] && . env/bin/activate
 set -e
 
 #requires brotli


### PR DESCRIPTION
Classic `sh` doesn't have `source` command. It's `bash` (and some other shells) specific. The original command is `.` (yes, just dot)