### PR TITLE
Fix a typo in the build-webfonts.sh script

### DIFF
--- a/sources/build-webfonts.sh
+++ b/sources/build-webfonts.sh
@@ -10,7 +10,7 @@ TT_DIR=./fonts/ttf
 echo ".
 CLEAN FONTS FOLDERS
 ."
-rm -rf $WEB_DIR/Users/philipp.nurullin/IdeaProjects/JetBrainsMono/sources/build-statics.sh
+rm -rf $WEB_DIR
 mkdir -p $WEB_DIR
 
 echo ".


### PR DESCRIPTION
It was introduced in the following commit: https://github.com/JetBrains/JetBrainsMono/commit/4de996505280f74099699ede938c8b478f702068

@philippnurullin 