### PR TITLE
Generate variable webfonts

### DIFF
--- a/.github/workflows/build-fonts.yml
+++ b/.github/workflows/build-fonts.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build fonts
         run: |
           gftools builder sources/config.yaml
-          python scripts/generate-variable-webfonts.py
+          python scripts/generate_variable_webfonts.py
       - name: Upload Fonts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-fonts.yml
+++ b/.github/workflows/build-fonts.yml
@@ -38,7 +38,9 @@ jobs:
           update-wheel: "true"
           update-setuptools: "true"
       - name: Build fonts
-        run: gftools builder sources/config.yaml
+        run: |
+          gftools builder sources/config.yaml
+          python scripts/generate-variable-webfonts.py
       - name: Upload Fonts
         uses: actions/upload-artifact@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 gftools
+fonttools[woff]

--- a/scripts/generate_variable_webfonts.py
+++ b/scripts/generate_variable_webfonts.py
@@ -5,4 +5,5 @@ from fontTools.ttLib import TTFont
 for filepath in glob.iglob('fonts/variable/*.ttf'):
 	f = TTFont(filepath)
 	f.flavor = 'woff2'
+	print('INFO:fontTools.ttLib.woff2:Building WOFF2 for ' + filepath)
 	f.save(os.path.splitext(filepath)[0] + '.woff2')

--- a/scripts/generate_variable_webfonts.py
+++ b/scripts/generate_variable_webfonts.py
@@ -1,0 +1,8 @@
+import glob
+import os
+from fontTools.ttLib import TTFont
+
+for filepath in glob.iglob('fonts/variable/*.ttf'):
+	f = TTFont(filepath)
+	f.flavor = 'woff2'
+	f.save(os.path.splitext(filepath)[0] + '.woff2')


### PR DESCRIPTION
This change adds `fontTools.ttLib` based build script that can generate variable webfonts from `ttf` files. It runs after the `gftools` and dumps the `woff2` fonts in `fonts/variable` directory. The script does not modify any files generated by `gftools`.

A test run for this change (not including upload) is available here: https://github.com/naiyerasif/JetBrainsMono/runs/5702196890?check_suite_focus=true