### PR TITLE
Fix README.md (chocolate -> chocolatey)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Once JetBrains Mono is installed in your OS, you are ready to configure the edit
 3. To enable ligatures, go to **Editor: Font Ligatures**, click **Edit in settings.json**, and copy this line `"editor.fontLigatures": true` into json file.
 
 ### **More ways to install**
-- [Chocolate](https://github.com/JetBrains/JetBrainsMono/wiki/Other-ways-to-install#through-chocolatey-windows-only)
+- [Chocolatey](https://github.com/JetBrains/JetBrainsMono/wiki/Other-ways-to-install#through-chocolatey-windows-only)
 - [ChromeOS terminal](https://github.com/JetBrains/JetBrainsMono/wiki/Other-ways-to-install#chromeos-terminal)
 
 ## Font Styles


### PR DESCRIPTION
The package manager [Chocolatey](https://chocolatey.org/) is mentioned as "Chocolate" in the README.

This PR fixes this error