### PR TITLE
Manually trigger builds

### DIFF
--- a/.github/workflows/build-fonts.yml
+++ b/.github/workflows/build-fonts.yml
@@ -1,6 +1,7 @@
 name: Build Fonts
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
I noticed in https://github.com/JetBrains/JetBrainsMono/issues/519#issuecomment-1386802931 that @philippnurullin mentioned the build generated by the merged PR would only be available on the next push (that changes sources/*).

I wanted to use the variable web fonts right away, so I [added `workflow_dispatch`](https://github.com/JetBrains/JetBrainsMono/issues/519#issuecomment-1386802931) to the list of events the build is triggered by. This should give the owner of the repository the ability to manually trigger a build from the GitHub Actions UI. @philippnurullin could use it to verify the generated files are correct rather than waiting for the next change to sources/*, and the artifact would have shown up in the Actions log for curious and impatient sleuths like me. 😅

I [successfully used it in my own fork](https://github.com/coldriverstudio/JetBrainsMono/actions/runs/4030158053) to manually trigger the build I wanted manually and generate the artifacts without making changes to sources/*. 