### PR TITLE
Remove unintentional space in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Select JetBrains Mono in the IDE settings: go to `Preferences/Settings` → `Edi
 
 ### Brew (macOS only)
 
-1. Tap the font cask to make the Jetbrains Mono font available :
+1. Tap the font cask to make the Jetbrains Mono font available:
 
     ```console
     brew tap homebrew/cask-fonts


### PR DESCRIPTION
This is a very small change that removes an extra space in the `README.md` file of the project. The space appears to be unintentional and was causing a minor formatting issue. By removing the extra space, the formatting has been corrected. This change has no impact on the functionality of the project, but it helps to improve the readability and presentation of the documentation.