### PR TITLE
misc: font-jetbrains-mono is now available under homebrew/cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,11 @@ Select JetBrains Mono in the IDE settings: go to `Preferences/Settings` → `Edi
 
 ### Brew (macOS only)
 
-1. Tap the font cask to make the Jetbrains Mono font available:
+Install it using the `font-jetbrains-mono` cask:
 
-    ```console
-    brew tap homebrew/cask-fonts
-    ```
-2. Install it using the `font-jetbrains-mono` cask:
-
-   ```console
-   brew install --cask font-jetbrains-mono
-   ```
+```console
+brew install --cask font-jetbrains-mono
+```
 
 ### Manual installation
 


### PR DESCRIPTION
Hello,

I recently noticed that cask-font has been deprecated (https://github.com/Homebrew/homebrew-cask-fonts), and font-jetbrains-mono is now available in homebrew/cask. This means there is no longer a need to tap any additional repositories.

This pull request updates the setup instructions to remove the tap operation. I have verified that it works on GitHub Actions (🔗 https://github.com/himkt/dotfiles/actions/runs/9244417280/job/25429681007), so it should be functional. 🤔