### PR TITLE
Typo fix Changelog.md

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -81,7 +81,7 @@ All notable changes to this project will be documented in this file.
 - Tuned Greek letters construction and contour polish #336
 - Removed `[||]` ligature to more consistence with `[|`  `|]` #353
 - Added `ϖ` #369
-- Fixed monospace breaking by tuning `⟵` `⟶` `⟷` arrows to fit standart width #387
+- Fixed monospace breaking by tuning `⟵` `⟶` `⟷` arrows to fit standard width #387
 - Added exclusion in `[<` `>]` to perform in `[<=5]` expression #388
 - Fixed Powerline arrows height #395
 


### PR DESCRIPTION
# Typo fix: Changelog.md

## Description
This pull request fixes a minor typo in `Changelog.md`. The word **`standart`** has been corrected to **`standard`** for improved clarity and professionalism.

### Changes
- Fixed the typo: `standart` → `standard`.

